### PR TITLE
Remove serde dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,6 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rpsl",
- "serde",
  "strum",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ ip_network_table = "0.2.0"
 log = "0.4.22"
 pcap = { version = "2.2.0" }
 pnet = { version = "0.35.0", features = ["std"] }
-serde = { version = "1.0.217", features = ["derive"] }
 
 [dev-dependencies]
 # These crates are only needed for running the examples.

--- a/src/models/probe.rs
+++ b/src/models/probe.rs
@@ -1,12 +1,10 @@
 use std::net::IpAddr;
 
-use serde::{Deserialize, Serialize};
-
 use crate::checksum::caracat_checksum;
 use crate::models::protocols::{L3, L4};
 
 /// The specification for a probe packet.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 pub struct Probe {
     pub dst_addr: IpAddr,
     pub src_port: u16,

--- a/src/models/protocols.rs
+++ b/src/models/protocols.rs
@@ -1,6 +1,5 @@
 use pnet::packet::ethernet::{EtherType, EtherTypes};
 use pnet::packet::ip::{IpNextHeaderProtocol, IpNextHeaderProtocols};
-use serde::{Deserialize, Serialize};
 
 /// Layer 2 protocol.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -30,7 +29,7 @@ impl From<L3> for EtherType {
 }
 
 /// Layer 4 protocol.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum L4 {
     ICMP,
     ICMPv6,

--- a/src/models/reply.rs
+++ b/src/models/reply.rs
@@ -3,12 +3,11 @@ use std::time::Duration;
 
 use pnet::packet::ip::IpNextHeaderProtocols;
 use pnet::packet::{icmp, icmpv6};
-use serde::Serialize;
 
 use crate::checksum::caracat_checksum;
 
 /// An MPLS label.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct MPLSLabel {
     /// This 20-bit field carries the actual value of the label.
     pub label: u32,
@@ -23,7 +22,7 @@ pub struct MPLSLabel {
 }
 
 /// A reply to a probe packet.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct Reply {
     // * Capture attributes *
     /// The capture timestamp.


### PR DESCRIPTION
Remove serde dependency from the project by:
- Removing serde from Cargo.toml dependencies
- Removing Serialize/Deserialize derives from L4, MPLSLabel, Reply, and Probe types
- Removing serde import statements from affected files

The project compiles successfully without serde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)